### PR TITLE
Proxy support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,9 @@ buildscript {
         classpath "com.gradle.publish:plugin-publish-plugin:0.9.7"
     }
 }
+
 group 'net.ossindex'
-version '0.1.1'
+version '0.1.2-SNAPSHOT'
 
 apply plugin: "com.gradle.plugin-publish"
 apply plugin: 'java'
@@ -25,7 +26,7 @@ repositories {
 
 dependencies {
     compile gradleApi()
-    compile 'net.ossindex:ossindex-api:2.0.3'
+    compile 'net.ossindex:ossindex-api:2.4.0'
     testCompile 'junit:junit:4.12'
     testCompile gradleTestKit()
     testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {
@@ -45,4 +46,8 @@ pluginBundle {
             displayName = 'OSSIndex Gradle Audit'
         }
     }
+}
+
+task showMeCache << {
+    configurations.compile.each { println it }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     compile gradleApi()
     compile 'net.ossindex:ossindex-api:2.4.0'
     testCompile 'junit:junit:4.12'
+    testCompile 'org.mockito:mockito-core:2.7.13'
     testCompile gradleTestKit()
     testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {
         exclude module: 'groovy-all'

--- a/src/main/java/net/ossindex/gradle/audit/AuditorFactory.java
+++ b/src/main/java/net/ossindex/gradle/audit/AuditorFactory.java
@@ -1,0 +1,22 @@
+package net.ossindex.gradle.audit;
+
+import java.util.List;
+import java.util.Set;
+
+import net.ossindex.gradle.input.ArtifactGatherer;
+import net.ossindex.gradle.input.GradleArtifact;
+
+/**
+ * Using a factory to make testing easier.
+ */
+public class AuditorFactory
+{
+  public DependencyAuditor getDependencyAuditor(Set< GradleArtifact > gradleArtifacts, List<Proxy> proxies) {
+    return new DependencyAuditor(gradleArtifacts, proxies);
+  }
+
+  public ArtifactGatherer getGatherer() {
+    ArtifactGatherer gatherer = new ArtifactGatherer();
+    return gatherer;
+  }
+}

--- a/src/main/java/net/ossindex/gradle/audit/DependencyAuditor.java
+++ b/src/main/java/net/ossindex/gradle/audit/DependencyAuditor.java
@@ -1,61 +1,78 @@
 package net.ossindex.gradle.audit;
 
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import net.ossindex.common.IPackageRequest;
 import net.ossindex.common.OssIndexApi;
 import net.ossindex.common.PackageDescriptor;
 import net.ossindex.gradle.input.GradleArtifact;
 import org.gradle.api.GradleException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.util.*;
+public class DependencyAuditor
+{
+  private static final Logger logger = LoggerFactory.getLogger(DependencyAuditor.class);
 
-public class DependencyAuditor {
-    private Map<PackageDescriptor, PackageDescriptor> parents = new HashMap<>();
-    private IPackageRequest request = OssIndexApi.createPackageRequest();
+  private Map<PackageDescriptor, PackageDescriptor> parents = new HashMap<>();
 
-    public DependencyAuditor(Set<GradleArtifact> gradleArtifacts) {
-        addArtifactsToAudit(gradleArtifacts);
+  private IPackageRequest request = OssIndexApi.createPackageRequest();
+
+  public DependencyAuditor(Set<GradleArtifact> gradleArtifacts, final List<Proxy> proxies) {
+    for (Proxy proxy : proxies) {
+      logger.error("Using proxy: " + proxy);
+      request.addProxy(proxy.getScheme(), proxy.getHost(), proxy.getPort(), proxy.getUser(), proxy.getPassword());
     }
+    addArtifactsToAudit(gradleArtifacts);
+  }
 
-    public Collection<MavenPackageDescriptor> runAudit() {
-        try {
-            List<MavenPackageDescriptor> results = new LinkedList<>();
-            Collection<PackageDescriptor> packages = request.run();
-            for (PackageDescriptor pkg : packages) {
-                MavenPackageDescriptor mvnPkg = new MavenPackageDescriptor(pkg);
-                if (parents.containsKey(pkg)) {
-                    PackageDescriptor parent = parents.get(pkg);
-                    if (parent != null) {
-                        mvnPkg.setParent(new MavenIdWrapper(parent));
-                    }
-                }
-                if (mvnPkg.getVulnerabilityMatches() > 0) {
-                    results.add(mvnPkg);
-                }
-            }
-            return results;
+  public Collection<MavenPackageDescriptor> runAudit() {
+    try {
+      List<MavenPackageDescriptor> results = new LinkedList<>();
+      Collection<PackageDescriptor> packages = request.run();
+      for (PackageDescriptor pkg : packages) {
+        MavenPackageDescriptor mvnPkg = new MavenPackageDescriptor(pkg);
+        if (parents.containsKey(pkg)) {
+          PackageDescriptor parent = parents.get(pkg);
+          if (parent != null) {
+            mvnPkg.setParent(new MavenIdWrapper(parent));
+          }
         }
-        catch(IOException e) {
-            throw new GradleException("Error trying to get audit results", e);
+        if (mvnPkg.getVulnerabilityMatches() > 0) {
+          results.add(mvnPkg);
         }
+      }
+      return results;
     }
+    catch (IOException e) {
+      throw new GradleException("Error trying to get audit results", e);
+    }
+  }
 
-    private void addArtifactsToAudit(Set<GradleArtifact> gradleArtifacts) {
-        gradleArtifacts.forEach(this::addArtifact);
-    }
+  private void addArtifactsToAudit(Set<GradleArtifact> gradleArtifacts) {
+    gradleArtifacts.forEach(this::addArtifact);
+  }
 
-    private void addPackageDependencies(PackageDescriptor parent, GradleArtifact gradleArtifact) {
-        PackageDescriptor pkgDep = new PackageDescriptor("maven", gradleArtifact.getGroup(), gradleArtifact.getName(), gradleArtifact.getVersion());
-        if (!parents.containsKey(pkgDep)) {
-            pkgDep = request.add("maven", gradleArtifact.getGroup(), gradleArtifact.getName(), gradleArtifact.getVersion());
-            parents.put(pkgDep, parent);
-        }
+  private void addPackageDependencies(PackageDescriptor parent, GradleArtifact gradleArtifact) {
+    PackageDescriptor pkgDep = new PackageDescriptor("maven", gradleArtifact.getGroup(), gradleArtifact.getName(),
+        gradleArtifact.getVersion());
+    if (!parents.containsKey(pkgDep)) {
+      pkgDep = request.add("maven", gradleArtifact.getGroup(), gradleArtifact.getName(), gradleArtifact.getVersion());
+      parents.put(pkgDep, parent);
     }
+  }
 
-    private void addArtifact(GradleArtifact gradleArtifact) {
-        PackageDescriptor parent = request.add("maven", gradleArtifact.getGroup(), gradleArtifact.getName(), gradleArtifact.getVersion());
-        parents.put(parent, null);
-        gradleArtifact.getAllChildren().forEach(c -> addPackageDependencies(parent, c));
-    }
+  private void addArtifact(GradleArtifact gradleArtifact) {
+    PackageDescriptor parent = request
+        .add("maven", gradleArtifact.getGroup(), gradleArtifact.getName(), gradleArtifact.getVersion());
+    parents.put(parent, null);
+    gradleArtifact.getAllChildren().forEach(c -> addPackageDependencies(parent, c));
+  }
 
 }

--- a/src/main/java/net/ossindex/gradle/audit/Proxy.java
+++ b/src/main/java/net/ossindex/gradle/audit/Proxy.java
@@ -1,0 +1,93 @@
+package net.ossindex.gradle.audit;
+
+public class Proxy
+{
+  private String scheme;
+
+  private String host;
+
+  private Integer port;
+
+  private String user;
+
+  private String password;
+
+  private String[] nonProxyHosts;
+
+  public String getScheme() {
+    return scheme;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public int getPort() {
+    if (port == null) {
+      switch (scheme) {
+        case "http":
+          return 80;
+        case "https":
+          return 443;
+        default:
+          throw new IllegalArgumentException("Unknown proxy scheme: " + scheme);
+      }
+    }
+    return port;
+  }
+
+  public String getUser() {
+    return user;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setScheme(final String scheme) {
+    this.scheme = scheme;
+  }
+
+  public void setHost(final String host) {
+    this.host = host;
+  }
+
+  public void setPort(final Integer port) {
+    this.port = port;
+  }
+
+  public void setUser(final String user) {
+    this.user = user;
+  }
+
+  public void setPassword(final String password) {
+    this.password = password;
+  }
+
+  public void setNonProxyHosts(final String nonProxyHosts) {
+    if (nonProxyHosts != null) {
+      this.nonProxyHosts = nonProxyHosts.split("|");
+    }
+  }
+
+  public boolean isValid() {
+    if (host == null) {
+      return false;
+    }
+
+    if (nonProxyHosts != null) {
+      for (String nonProxyHost: nonProxyHosts) {
+        if (host.equals(nonProxyHost)) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return user + "@" + host + ":" + getPort();
+  }
+}

--- a/src/main/java/net/ossindex/gradle/audit/Proxy.java
+++ b/src/main/java/net/ossindex/gradle/audit/Proxy.java
@@ -1,5 +1,7 @@
 package net.ossindex.gradle.audit;
 
+import java.util.Objects;
+
 public class Proxy
 {
   private String scheme;
@@ -89,5 +91,19 @@ public class Proxy
   @Override
   public String toString() {
     return user + "@" + host + ":" + getPort();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof Proxy) {
+      Proxy p = (Proxy)o;
+      return Objects.equals(scheme, p.scheme) &&
+          Objects.equals(host, p.host) &&
+          Objects.equals(port, p.port) &&
+          Objects.equals(user, p.user) &&
+          Objects.equals(password, p.password) &&
+          Objects.equals(nonProxyHosts, p.nonProxyHosts);
+    }
+    return false;
   }
 }

--- a/src/test/groovy/net/ossindex/integrationtests/ProxyTests.java
+++ b/src/test/groovy/net/ossindex/integrationtests/ProxyTests.java
@@ -1,0 +1,128 @@
+package net.ossindex.integrationtests;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Set;
+
+import net.ossindex.gradle.OssIndexPlugin;
+import net.ossindex.gradle.audit.AuditorFactory;
+import net.ossindex.gradle.audit.DependencyAuditor;
+import net.ossindex.gradle.audit.Proxy;
+import net.ossindex.gradle.input.ArtifactGatherer;
+import net.ossindex.gradle.input.GradleArtifact;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.plugins.ExtensionContainer;
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ProxyTests
+{
+  private static final String PROXY_HOST = "example.com";
+  private static final Integer PROXY_PORT = 8080;
+  private static final String PROXY_USER = "username";
+  private static final String PROXY_PASS = "password";
+  private static final String NON_PROXY_HOSTS = "ossindex.net|ossindex.sonatype.org";
+
+  @Test
+  public void noProxyTest() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+    Project project = mock(Project.class);
+
+    OssIndexPlugin plugin = new OssIndexPlugin();
+    AuditorFactory factory = mockAuditorFactory();
+    plugin.setAuditorFactory(mockAuditorFactory());
+    plugin.apply(project);
+    runAudit(project, plugin);
+
+    verify(factory).getDependencyAuditor(Collections.EMPTY_SET, Collections.EMPTY_LIST);
+  }
+
+  @Test
+  public void httpProxyTest() throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
+    Project project = mockProject();
+    mockProxy(project, "http");
+
+    OssIndexPlugin plugin = new OssIndexPlugin();
+    AuditorFactory factory = mockAuditorFactory();
+    plugin.setAuditorFactory(mockAuditorFactory());
+
+    plugin.apply(project);
+    runAudit(project, plugin);
+
+    verify(factory).getDependencyAuditor(Collections.EMPTY_SET, Collections.singletonList(getProxy("http")));
+  }
+
+  @Test
+  public void httpsProxyTest() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+    Project project = mockProject();
+    mockProxy(project, "https");
+
+    OssIndexPlugin plugin = new OssIndexPlugin();
+    AuditorFactory factory = mockAuditorFactory();
+    plugin.setAuditorFactory(mockAuditorFactory());
+
+    plugin.apply(project);
+    runAudit(project, plugin);
+
+    verify(factory).getDependencyAuditor(Collections.EMPTY_SET, Collections.singletonList(getProxy("https")));
+  }
+
+  /**
+   * A terrible hack that shortcuts the internal workings of gradle to allow some simple tests to work
+   */
+  private void runAudit(final Project project, final OssIndexPlugin plugin)
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException
+  {
+    Method method = OssIndexPlugin.class.getDeclaredMethod("doAudit", Task.class);
+    method.setAccessible(true);
+    method.invoke(plugin, project.task("audit"));
+  }
+
+  private AuditorFactory mockAuditorFactory() {
+    AuditorFactory factory = mock(AuditorFactory.class);
+
+    ArtifactGatherer gatherer = mock(ArtifactGatherer.class);
+    when(gatherer.gatherResolvedArtifacts(any())).thenReturn(Collections.EMPTY_SET);
+    when(factory.getGatherer()).thenReturn(gatherer);
+
+    DependencyAuditor auditor  = mock(DependencyAuditor.class);
+    when(factory.getDependencyAuditor(any(), any())).thenReturn(auditor);
+    return factory;
+  }
+
+  private Project mockProject() {
+    Project project = mock(Project.class);
+
+    ExtensionContainer extension = mock(ExtensionContainer.class);
+    when(project.getExtensions()).thenReturn(extension);
+
+    Task audit = mock(Task.class);
+    when(audit.getProject()).thenReturn(project);
+    when(project.task("audit")).thenReturn(audit);
+
+    return project;
+  }
+
+  private void mockProxy(final Project project, final String scheme) {
+    when(project.findProperty("systemProp." + scheme + ".proxyHost")).thenReturn(PROXY_HOST);
+    when(project.findProperty("systemProp." + scheme + ".proxyPort")).thenReturn(PROXY_PORT.toString());
+    when(project.findProperty("systemProp." + scheme + ".proxyUser")).thenReturn(PROXY_USER);
+    when(project.findProperty("systemProp." + scheme + ".proxyPassword")).thenReturn(PROXY_PASS);
+    when(project.findProperty("systemProp." + scheme + ".nonProxyHosts")).thenReturn(null);
+  }
+
+  private Proxy getProxy(final String scheme) {
+    Proxy proxy = new Proxy();
+    proxy.setHost(PROXY_HOST);
+    proxy.setPort(PROXY_PORT);
+    proxy.setUser(PROXY_USER);
+    proxy.setPassword(PROXY_PASS);
+    proxy.setNonProxyHosts(null);
+    return proxy;
+  }
+}

--- a/src/test/groovy/net/ossindex/integrationtests/ProxyTests.java
+++ b/src/test/groovy/net/ossindex/integrationtests/ProxyTests.java
@@ -3,14 +3,12 @@ package net.ossindex.integrationtests;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collections;
-import java.util.Set;
 
 import net.ossindex.gradle.OssIndexPlugin;
 import net.ossindex.gradle.audit.AuditorFactory;
 import net.ossindex.gradle.audit.DependencyAuditor;
 import net.ossindex.gradle.audit.Proxy;
 import net.ossindex.gradle.input.ArtifactGatherer;
-import net.ossindex.gradle.input.GradleArtifact;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.plugins.ExtensionContainer;
@@ -21,68 +19,88 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+/**
+ * A series of tests that simulate the operation of gradle and ensure that appropriate proxy arguments are
+ * passed to the DependencyAuditor.
+ */
 public class ProxyTests
 {
   private static final String PROXY_HOST = "example.com";
+
   private static final Integer PROXY_PORT = 8080;
+
   private static final String PROXY_USER = "username";
+
   private static final String PROXY_PASS = "password";
+
   private static final String NON_PROXY_HOSTS = "ossindex.net|ossindex.sonatype.org";
 
+  /**
+   * Ensure that OssIndexPlugin properly assembles the proxy argument and passes it to the DependencyAuditor.
+   * If the dependency auditor receives proxy information it is passed directly to the OSS Index request
+   * library.
+   */
   @Test
   public void noProxyTest() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-    Project project = mock(Project.class);
+    Project project = mockProject();
 
     OssIndexPlugin plugin = new OssIndexPlugin();
     AuditorFactory factory = mockAuditorFactory();
-    plugin.setAuditorFactory(mockAuditorFactory());
-    plugin.apply(project);
-    runAudit(project, plugin);
+    plugin.setAuditorFactory(factory);
+
+    // Simulate the process the gradle runs
+    runGradleSimulation(project, plugin);
 
     verify(factory).getDependencyAuditor(Collections.EMPTY_SET, Collections.EMPTY_LIST);
   }
 
+  /**
+   * Ensure that OssIndexPlugin properly assembles the proxy argument and passes it to the DependencyAuditor.
+   */
   @Test
   public void httpProxyTest() throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
     Project project = mockProject();
+
+    // Mock the proxy being provided as project properties
     mockProxy(project, "http");
 
     OssIndexPlugin plugin = new OssIndexPlugin();
     AuditorFactory factory = mockAuditorFactory();
-    plugin.setAuditorFactory(mockAuditorFactory());
+    plugin.setAuditorFactory(factory);
 
-    plugin.apply(project);
-    runAudit(project, plugin);
+    // Simulate the process the gradle runs
+    runGradleSimulation(project, plugin);
 
-    verify(factory).getDependencyAuditor(Collections.EMPTY_SET, Collections.singletonList(getProxy("http")));
+    verify(factory).getDependencyAuditor(Collections.EMPTY_SET, Collections.singletonList(getExpectedProxy("http")));
   }
 
+  /**
+   * Ensure that OssIndexPlugin properly assembles the proxy argument and passes it to the DependencyAuditor.
+   */
   @Test
   public void httpsProxyTest() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
     Project project = mockProject();
+
+    // Mock the proxy being provided as project properties
     mockProxy(project, "https");
 
     OssIndexPlugin plugin = new OssIndexPlugin();
     AuditorFactory factory = mockAuditorFactory();
-    plugin.setAuditorFactory(mockAuditorFactory());
+    plugin.setAuditorFactory(factory);
 
-    plugin.apply(project);
-    runAudit(project, plugin);
+    // Simulate the process the gradle runs
+    runGradleSimulation(project, plugin);
 
-    verify(factory).getDependencyAuditor(Collections.EMPTY_SET, Collections.singletonList(getProxy("https")));
+    verify(factory).getDependencyAuditor(Collections.EMPTY_SET, Collections.singletonList(getExpectedProxy("https")));
   }
 
   /**
-   * A terrible hack that shortcuts the internal workings of gradle to allow some simple tests to work
+   * Mock the factory used by the auditor. The factory was specifically created to simplify unit tests. The factory
+   * allows the assembly of:
+   *
+   * - The artifact gatherer. This is normally provided by gradle, but needs mocking for testing purposes.
+   * - The dependency auditor. For normal usage this is directly instantiated.
    */
-  private void runAudit(final Project project, final OssIndexPlugin plugin)
-      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException
-  {
-    Method method = OssIndexPlugin.class.getDeclaredMethod("doAudit", Task.class);
-    method.setAccessible(true);
-    method.invoke(plugin, project.task("audit"));
-  }
-
   private AuditorFactory mockAuditorFactory() {
     AuditorFactory factory = mock(AuditorFactory.class);
 
@@ -90,11 +108,14 @@ public class ProxyTests
     when(gatherer.gatherResolvedArtifacts(any())).thenReturn(Collections.EMPTY_SET);
     when(factory.getGatherer()).thenReturn(gatherer);
 
-    DependencyAuditor auditor  = mock(DependencyAuditor.class);
+    DependencyAuditor auditor = mock(DependencyAuditor.class);
     when(factory.getDependencyAuditor(any(), any())).thenReturn(auditor);
     return factory;
   }
 
+  /**
+   * Assemble the gradle project with appropriate task.
+   */
   private Project mockProject() {
     Project project = mock(Project.class);
 
@@ -108,6 +129,9 @@ public class ProxyTests
     return project;
   }
 
+  /**
+   * Mock the project properties for a specified proxy
+   */
   private void mockProxy(final Project project, final String scheme) {
     when(project.findProperty("systemProp." + scheme + ".proxyHost")).thenReturn(PROXY_HOST);
     when(project.findProperty("systemProp." + scheme + ".proxyPort")).thenReturn(PROXY_PORT.toString());
@@ -116,7 +140,10 @@ public class ProxyTests
     when(project.findProperty("systemProp." + scheme + ".nonProxyHosts")).thenReturn(null);
   }
 
-  private Proxy getProxy(final String scheme) {
+  /**
+   * The proxy expected as part of the test
+   */
+  private Proxy getExpectedProxy(final String scheme) {
     Proxy proxy = new Proxy();
     proxy.setHost(PROXY_HOST);
     proxy.setPort(PROXY_PORT);
@@ -125,4 +152,21 @@ public class ProxyTests
     proxy.setNonProxyHosts(null);
     return proxy;
   }
+
+
+  /**
+   * Simulate gradle operations
+   *
+   * This is a terrible hack that shortcuts the internal workings of gradle to allow some simple tests to work
+   */
+  private void runGradleSimulation(final Project project, final OssIndexPlugin plugin)
+      throws NoSuchMethodException, IllegalAccessException, InvocationTargetException
+  {
+    plugin.apply(project);
+
+    Method method = OssIndexPlugin.class.getDeclaredMethod("doAudit", Task.class);
+    method.setAccessible(true);
+    method.invoke(plugin, project.task("audit"));
+  }
+
 }


### PR DESCRIPTION
Add simple proxy support, using what appear to be standard grade properties as seen here:

* https://stackoverflow.com/questions/41507037/how-to-set-proxy-server-for-gradle?rq=1
* https://stackoverflow.com/questions/5991194/gradle-proxy-configuration

Some of the changes made to operational code (the addition of a factory) were done solely to allow for simplified unit testing of new code.

Tests were added to ensure that expected properties were appropriately passed to the OSS Index Java API library. The library should support requests through a proxy.