### PR TITLE
OSS Index API v3.0 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,32 @@ following, where the package and vulnerability details depends on what is identi
 
 ![Failure](docs/Vulnerabilities.PNG)
 
+### Credentials
+
+The OSS Index API is rate limited. In many cases the limit is more than
+sufficient, however in heavier use cases an increased limit might be desired.
+This can be attained by creating a user account at
+[OSS Index](https://ossindex.sonatype.org) and supplying the username and `token`
+to the plugin. The `token` can be retrieved from the OSS Index settings page
+of the user.
+
+As you don't want credentials stored in a source repository, you use the
+gradle properties file to specify the cache folder. In the gradle properties,
+write this:
+
+```
+ossindexUser = user@example.com
+ossindexToken = ef40752eeb642ba1c3df1893d270c6f9fb7ab9e1
+```
+
+In your build.gradle file, add this:
+
+```
+audit {
+        user = ossindexUser
+        token = ossindexToken
+    }
+```
 
 ### Dependency tree of vulnerabilities
 If the `--info` flag is provided to gradle it will output a dependency tree which shows the transitive dependencies which have vulnerabilities.
@@ -305,3 +331,14 @@ audit {
 }
 ```
 
+### Cache
+
+In order to reduce round trips to OSS Index (as there is rate limiting), a
+local cache file is used. By default it is in the `.ossindex` directory
+in the users home folder. This location can be overloaded.
+
+```
+audit {
+    cache = "/tmp/ossindex.cache"
+}
+```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # ossindex-gradle-plugin
-Audits a [gradle](https://gradle.org/) project using the [OSS Index REST API v2.0](https://ossindex.net) to identify known vulnerabilities in its dependencies.
+Audits a [gradle](https://gradle.org/) project using the [OSS Index REST API v3](https://ossindex.sonatype.org/rest) to identify known vulnerabilities in its dependencies.
+
+New Release Notes
+-------------
+
+This release uses the new OSS Index v3 API. There are a few differences of note:
+
+* Vulnerability IDs have changed, they are now UUIDs instead of long integers.
+  These should not change again: sorry for the inconvenience.
+* The new API has rate limiting, which is higher for authenticated users. Many
+  users should be fine running unauthenticated, but if you start running
+  into rate limit issues this can easily be resolved by getting a free OSS Index
+  account and providing credentials (discussed below).
+* We have added results caching in an attempt to reduce server hits (and thus
+  reduce rate limit problems). Setting the cache location is described below.
+
 
 Requirements
 -------------

--- a/README.md
+++ b/README.md
@@ -125,11 +125,14 @@ gradle properties file to specify the cache folder. In the gradle properties,
 write this:
 
 ```
-ossindexUser = user@example.com
-ossindexToken = ef40752eeb642ba1c3df1893d270c6f9fb7ab9e1
+ossindexUser=user@example.com
+ossindexToken=ef40752eeb642ba1c3df1893d270c6f9fb7ab9e1
 ```
 
-In your build.gradle file, add this:
+In your build.gradle file, add one of the following. It seems that some users
+have different config formats (perhaps gradle version related?):
+
+either
 
 ```
 audit {
@@ -137,6 +140,16 @@ audit {
         token = ossindexToken
     }
 ```
+
+or
+
+```
+audit {
+        user = "$ossindexUser"
+        token = "$ossindexToken"
+    }
+```
+
 
 ### Dependency tree of vulnerabilities
 If the `--info` flag is provided to gradle it will output a dependency tree which shows the transitive dependencies which have vulnerabilities.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Audits a [gradle](https://gradle.org/) project using the [OSS Index REST API v3]
 New Release Notes
 -------------
 
-This release uses the new OSS Index v3 API. There are a few differences of note:
+**This release uses the new OSS Index v3 API**. There are a few differences of note:
 
 * Vulnerability IDs have changed, they are now UUIDs instead of long integers.
   These should not change again: sorry for the inconvenience.
@@ -129,19 +129,7 @@ ossindexUser=user@example.com
 ossindexToken=ef40752eeb642ba1c3df1893d270c6f9fb7ab9e1
 ```
 
-In your build.gradle file, add one of the following. It seems that some users
-have different config formats (perhaps gradle version related?):
-
-either
-
-```
-audit {
-        user = ossindexUser
-        token = ossindexToken
-    }
-```
-
-or
+In your build.gradle file, add the following.
 
 ```
 audit {

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ sourceCompatibility = 1.8
 
 repositories {
     mavenCentral()
-    mavenLocal()
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ repositories {
 
 dependencies {
     compile gradleApi()
-    compile 'net.ossindex:ossindex-api:3.0.3'
+    compile 'net.ossindex:ossindex-api:3.0.5'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.7.13'
     testCompile gradleTestKit()

--- a/build.gradle
+++ b/build.gradle
@@ -25,11 +25,12 @@ sourceCompatibility = 1.8
 
 repositories {
     mavenCentral()
+    mavenLocal()
 }
 
 dependencies {
     compile gradleApi()
-    compile 'net.ossindex:ossindex-api:2.5.2'
+    compile 'net.ossindex:ossindex-api:3.0.0'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.7.13'
     testCompile gradleTestKit()

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ repositories {
 
 dependencies {
     compile gradleApi()
-    compile 'net.ossindex:ossindex-api:3.0.5'
+    compile 'net.ossindex:ossindex-api:3.0.9'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.7.13'
     testCompile gradleTestKit()

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 }
 
 group 'net.ossindex'
-version '0.4.0'
+version '0.4.0-beta'
 
 apply plugin: "com.gradle.plugin-publish"
 apply plugin: 'java'

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 }
 
 group 'net.ossindex'
-version '0.3.20-beta'
+version '0.4.0'
 
 apply plugin: "com.gradle.plugin-publish"
 apply plugin: 'java'

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ repositories {
 
 dependencies {
     compile gradleApi()
-    compile 'net.ossindex:ossindex-api:3.0.0'
+    compile 'net.ossindex:ossindex-api:3.0.3'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.7.13'
     testCompile gradleTestKit()

--- a/src/main/java/net/ossindex/gradle/AuditExtensions.java
+++ b/src/main/java/net/ossindex/gradle/AuditExtensions.java
@@ -4,6 +4,7 @@ import groovy.lang.Closure;
 import net.ossindex.gradle.audit.MavenPackageDescriptor;
 import org.gradle.api.Project;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -31,6 +32,8 @@ public class AuditExtensions
   public String proxyPassword;
 
   public String nonProxyHosts;
+
+  public String cache;
 
   public AuditExtensions(Project project) {
     this.project = project;

--- a/src/main/java/net/ossindex/gradle/AuditExtensions.java
+++ b/src/main/java/net/ossindex/gradle/AuditExtensions.java
@@ -39,6 +39,12 @@ public class AuditExtensions
 
   public String token;
 
+  public Integer packagesPerRequest;
+
+  public Boolean rateLimitAsError;
+
+  public Integer cacheTimeout;
+
   public AuditExtensions(Project project) {
     this.project = project;
   }

--- a/src/main/java/net/ossindex/gradle/AuditExtensions.java
+++ b/src/main/java/net/ossindex/gradle/AuditExtensions.java
@@ -35,6 +35,10 @@ public class AuditExtensions
 
   public String cache;
 
+  public String user;
+
+  public String token;
+
   public AuditExtensions(Project project) {
     this.project = project;
   }

--- a/src/main/java/net/ossindex/gradle/OssIndexPlugin.java
+++ b/src/main/java/net/ossindex/gradle/OssIndexPlugin.java
@@ -37,6 +37,7 @@ public class OssIndexPlugin implements Plugin<Project> {
 
     @Override
     public synchronized void apply(Project project) {
+        logger.info("Apply OSS Index Plugin");
         this.project = project;
 
         project.getExtensions().create("audit", AuditExtensions.class, project);

--- a/src/main/java/net/ossindex/gradle/audit/DependencyAuditor.java
+++ b/src/main/java/net/ossindex/gradle/audit/DependencyAuditor.java
@@ -1,5 +1,6 @@
 package net.ossindex.gradle.audit;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -56,6 +57,31 @@ public class DependencyAuditor
         exclusion.apply(filter);
       }
       request.addVulnerabilityFilter(filter);
+      if (config.cache != null) {
+        File file = new File(config.cache);
+        if (file.exists()) {
+          if (!file.isFile()) {
+            throw new GradleException("cache option must specify a file (" + config.cache + ")");
+          }
+          if (!file.canWrite()) {
+            throw new GradleException("cannot write to the specified cache file (" + config.cache + ")");
+          }
+        }
+        File parentDir = file.getParentFile();
+        if (parentDir.exists()) {
+          if (!parentDir.canWrite()) {
+            throw new GradleException("cannot write to cache dir (" + config.cache + ")");
+          }
+          if (!parentDir.canExecute()) {
+            throw new GradleException("cannot access cache dir, need execute permissions on dir (" + config.cache + ")");
+          }
+        } else {
+          if (!parentDir.mkdirs()) {
+            throw new GradleException("cannot create dir for cache (" + config.cache + ")");
+          }
+        }
+        request.setCacheFile(file.getAbsolutePath());
+      }
     }
   }
 

--- a/src/main/java/net/ossindex/gradle/audit/DependencyAuditor.java
+++ b/src/main/java/net/ossindex/gradle/audit/DependencyAuditor.java
@@ -12,9 +12,8 @@ import java.util.Set;
 
 import net.ossindex.common.IPackageRequest;
 import net.ossindex.common.OssIndexApi;
+import net.ossindex.common.OssiPackage;
 import net.ossindex.common.PackageCoordinate;
-import net.ossindex.common.PackageDescriptor;
-import net.ossindex.common.VulnerabilityDescriptor;
 import net.ossindex.common.filter.IVulnerabilityFilter;
 import net.ossindex.common.filter.VulnerabilityFilterFactory;
 import net.ossindex.gradle.AuditExclusion;
@@ -24,21 +23,13 @@ import org.gradle.api.GradleException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 public class DependencyAuditor
 {
   private static final Logger logger = LoggerFactory.getLogger(DependencyAuditor.class);
 
   private final AuditExtensions config;
 
-  private Map<PackageDescriptor, PackageDescriptor> parents = new HashMap<>();
+  private Map<OssiPackage, OssiPackage> parents = new HashMap<>();
 
   private IPackageRequest request;
 
@@ -46,7 +37,7 @@ public class DependencyAuditor
                            Set<GradleArtifact> gradleArtifacts,
                            final List<Proxy> proxies)
   {
-    this.config =  auditConfig;
+    this.config = auditConfig;
     for (Proxy proxy : proxies) {
       logger.info("Using proxy: " + proxy);
       OssIndexApi.addProxy(proxy.getScheme(), proxy.getHost(), proxy.getPort(), proxy.getUser(), proxy.getPassword());
@@ -71,11 +62,11 @@ public class DependencyAuditor
   public Collection<MavenPackageDescriptor> runAudit() {
     try {
       List<MavenPackageDescriptor> results = new LinkedList<>();
-      Collection<PackageDescriptor> packages = request.run();
-      for (PackageDescriptor pkg : packages) {
+      Collection<OssiPackage> packages = request.run();
+      for (OssiPackage pkg : packages) {
         MavenPackageDescriptor mvnPkg = new MavenPackageDescriptor(pkg);
         if (parents.containsKey(pkg)) {
-          PackageDescriptor parent = parents.get(pkg);
+          OssiPackage parent = parents.get(pkg);
           if (parent != null) {
             mvnPkg.setParent(new MavenIdWrapper(parent));
           }
@@ -97,17 +88,20 @@ public class DependencyAuditor
 
   private void addArtifact(GradleArtifact gradleArtifact) {
     PackageCoordinate parentCoordinate = buildCoordinate(gradleArtifact);
-    PackageDescriptor parent = request.add(Collections.singletonList(parentCoordinate));
+    OssiPackage parent = request.add(Collections.singletonList(parentCoordinate));
     parents.put(parent, null);
     gradleArtifact.getAllChildren().forEach(c -> addPackageDependencies(parent, parentCoordinate, c));
   }
 
-  private void addPackageDependencies(PackageDescriptor parent, PackageCoordinate parentCoordinate, GradleArtifact gradleArtifact) {
-    PackageDescriptor pkgDep = new PackageDescriptor("maven", gradleArtifact.getGroup(), gradleArtifact.getName(),
+  private void addPackageDependencies(OssiPackage parent,
+                                      PackageCoordinate parentCoordinate,
+                                      GradleArtifact gradleArtifact)
+  {
+    OssiPackage pkgDep = new OssiPackage("maven", gradleArtifact.getGroup(), gradleArtifact.getName(),
         gradleArtifact.getVersion());
     if (!parents.containsKey(pkgDep)) {
       PackageCoordinate childCoordinate = buildCoordinate(gradleArtifact);
-      pkgDep = request.add(Arrays.asList(new PackageCoordinate[] {parentCoordinate, childCoordinate}));
+      pkgDep = request.add(Arrays.asList(new PackageCoordinate[]{parentCoordinate, childCoordinate}));
       parents.put(pkgDep, parent);
     }
   }
@@ -123,6 +117,6 @@ public class DependencyAuditor
   }
 
   private String toString(PackageCoordinate pkg) {
-    return pkg.getFormat() + ":" + pkg.getNamespace() + ":" + pkg.getName() + ":" + pkg.getVersion();
+    return pkg.getNamespace() + ":" + pkg.getNamespace() + ":" + pkg.getName() + ":" + pkg.getVersion();
   }
 }

--- a/src/main/java/net/ossindex/gradle/audit/DependencyAuditor.java
+++ b/src/main/java/net/ossindex/gradle/audit/DependencyAuditor.java
@@ -40,9 +40,17 @@ public class DependencyAuditor
                            final List<Proxy> proxies)
   {
     this.config = auditConfig;
-    for (Proxy proxy : proxies) {
-      logger.info("Using proxy: " + proxy);
-      OssIndexApi.addProxy(proxy.getScheme(), proxy.getHost(), proxy.getPort(), proxy.getUser(), proxy.getPassword());
+    switch(proxies.size()) {
+      case 0:
+        logger.info("Direct OSSI connection (" + proxies.size() + " proxies configured)");
+        break;
+      default:
+        logger.info("Using proxy (" + proxies.size() + ")");
+        for (Proxy proxy : proxies) {
+          logger.info("  * " + proxy);
+          OssIndexApi.addProxy(proxy.getScheme(), proxy.getHost(), proxy.getPort(), proxy.getUser(), proxy.getPassword());
+        }
+        break;
     }
 
     request = OssIndexApi.createPackageRequest();

--- a/src/main/java/net/ossindex/gradle/audit/DependencyAuditor.java
+++ b/src/main/java/net/ossindex/gradle/audit/DependencyAuditor.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.base.Strings;
 import net.ossindex.common.IPackageRequest;
 import net.ossindex.common.OssIndexApi;
 import net.ossindex.common.OssiPackage;
@@ -51,13 +52,16 @@ public class DependencyAuditor
 
   private void configure() {
     if (config != null) {
+      // Filter configuration
       IVulnerabilityFilter filter = VulnerabilityFilterFactory.getInstance().createVulnerabilityFilter();
       Collection<AuditExclusion> exclusions = config.getExclusions();
       for (AuditExclusion exclusion : exclusions) {
         exclusion.apply(filter);
       }
       request.addVulnerabilityFilter(filter);
-      if (config.cache != null) {
+
+      // Cache configuration
+      if (!Strings.isNullOrEmpty(config.cache )) {
         File file = new File(config.cache);
         if (file.exists()) {
           if (!file.isFile()) {
@@ -81,6 +85,11 @@ public class DependencyAuditor
           }
         }
         request.setCacheFile(file.getAbsolutePath());
+      }
+
+      // Credentials configuration
+      if (!Strings.isNullOrEmpty(config.user) && !Strings.isNullOrEmpty(config.token)) {
+        request.setCredentials(config.user, config.token);
       }
     }
   }

--- a/src/main/java/net/ossindex/gradle/audit/MavenIdWrapper.java
+++ b/src/main/java/net/ossindex/gradle/audit/MavenIdWrapper.java
@@ -1,6 +1,6 @@
 package net.ossindex.gradle.audit;
 
-import net.ossindex.common.PackageDescriptor;
+import net.ossindex.common.OssiPackage;
 
 public class MavenIdWrapper {
 
@@ -30,8 +30,8 @@ public class MavenIdWrapper {
 
     }
 
-    public MavenIdWrapper(PackageDescriptor pkg) {
-        this.setGroupId(pkg.getGroup());
+    public MavenIdWrapper(OssiPackage pkg) {
+        this.setGroupId(pkg.getNamespace());
         this.setArtifactId(pkg.getName());
         this.setVersion(pkg.getVersion());
     }

--- a/src/main/java/net/ossindex/gradle/audit/MavenPackageDescriptor.java
+++ b/src/main/java/net/ossindex/gradle/audit/MavenPackageDescriptor.java
@@ -1,7 +1,7 @@
 package net.ossindex.gradle.audit;
 
-import net.ossindex.common.PackageDescriptor;
-import net.ossindex.common.VulnerabilityDescriptor;
+import net.ossindex.common.OssiPackage;
+import net.ossindex.common.OssiVulnerability;
 import org.gradle.internal.impldep.com.google.gson.annotations.SerializedName;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -12,9 +12,9 @@ public class MavenPackageDescriptor extends MavenIdWrapper {
 
     private MavenIdWrapper parent;
 
-    @XmlElement(name = "vulnerability-total")
-    @SerializedName("vulnerability-total")
-    private int vulnerabilityTotal;
+    @XmlElement(name = "unfiltered-vulnerability-count")
+    @SerializedName("unfiltered-vulnerability-count")
+    private int unfilteredVulnerabilityCount;
 
     @XmlElement(name = "vulnerability-matches")
     @SerializedName("vulnerability-matches")
@@ -22,7 +22,7 @@ public class MavenPackageDescriptor extends MavenIdWrapper {
 
     @XmlElementWrapper(name = "vulnerabilities")
     @XmlElement(name = "vulnerability")
-    private List<VulnerabilityDescriptor> vulnerabilities;
+    private List<OssiVulnerability> vulnerabilities;
 
     /**
      * Constructor required by jaxb
@@ -31,13 +31,13 @@ public class MavenPackageDescriptor extends MavenIdWrapper {
 
     }
 
-    public MavenPackageDescriptor(PackageDescriptor pkg) {
-        groupId = pkg.getGroup();
+    public MavenPackageDescriptor(OssiPackage pkg) {
+        groupId = pkg.getNamespace();
         artifactId = pkg.getName();
         version = pkg.getVersion();
-        vulnerabilityTotal = pkg.getVulnerabilityTotal();
-        vulnerabilityMatches = pkg.getVulnerabilityMatches();
         vulnerabilities = pkg.getVulnerabilities();
+        unfilteredVulnerabilityCount = pkg.getUnfilteredVulnerabilityMatches();
+        vulnerabilityMatches = vulnerabilities.size();
     }
 
     public void setParent(MavenIdWrapper parent) {
@@ -49,12 +49,12 @@ public class MavenPackageDescriptor extends MavenIdWrapper {
     }
 
     /**
-     * Get the total number of vulnerabilities for the package identified on the server.
+     * Get the number of vulnerabilities matching the supplied version, prior to any exclusions and filtering.
      *
      * @return Total number of vulnerabilities.
      */
-    public int getVulnerabilityTotal() {
-        return vulnerabilityTotal;
+    public int getUnfilteredVulnerabilityCount() {
+        return unfilteredVulnerabilityCount;
     }
 
     /**
@@ -71,7 +71,7 @@ public class MavenPackageDescriptor extends MavenIdWrapper {
      *
      * @return all vulnerabilities
      */
-    public List<VulnerabilityDescriptor> getVulnerabilities() {
+    public List<OssiVulnerability> getVulnerabilities() {
         return vulnerabilities;
     }
 

--- a/src/main/java/net/ossindex/gradle/output/AuditResultReporter.java
+++ b/src/main/java/net/ossindex/gradle/output/AuditResultReporter.java
@@ -117,7 +117,6 @@ public class AuditResultReporter
                 importingArtifact.getFullDescription(),
                 descriptor.getMavenVersionId(),
                 descriptor.getVulnerabilityMatches());
-                descriptor.getMavenVersionId(), descriptor.getVulnerabilityMatches());
         logger.error(currentVulnerableArtifact);
     }
 

--- a/src/main/java/net/ossindex/gradle/output/AuditResultReporter.java
+++ b/src/main/java/net/ossindex/gradle/output/AuditResultReporter.java
@@ -16,133 +16,133 @@ import org.slf4j.LoggerFactory;
 
 public class AuditResultReporter
 {
-  private static final Logger logger = LoggerFactory.getLogger(AuditResultReporter.class);
+    private static final Logger logger = LoggerFactory.getLogger(AuditResultReporter.class);
 
-  private static final String OSSI_VULN_PREFIX = "https://ossindex.sonatype.org/vuln/";
+    private static final String OSSI_VULN_PREFIX = "https://ossindex.sonatype.org/vuln/";
 
-  private final Set<GradleArtifact> resolvedTopLevelArtifacts;
+    private final Set<GradleArtifact> resolvedTopLevelArtifacts;
 
-  private final AuditExtensions settings;
+    private final AuditExtensions settings;
 
-  private Set<GradleArtifact> allGradleArtifacts;
+    private Set<GradleArtifact> allGradleArtifacts;
 
-  private String currentVulnerableArtifact = null;
+    private String currentVulnerableArtifact = null;
 
-  ArrayList<String> currentVulnerabilityList = new ArrayList<>();
+    ArrayList<String> currentVulnerabilityList = new ArrayList<>();
 
-  private String currentVulnerabilityTotals = null;
+    private String currentVulnerabilityTotals = null;
 
-  private String thisTask;
+    private String thisTask;
 
-  private JunitXmlReportWriter junitXmlReportWriter;
+    private JunitXmlReportWriter junitXmlReportWriter;
 
-  public AuditResultReporter(Set<GradleArtifact> resolvedTopLevelArtifacts,
-                             AuditExtensions settings,
-                             JunitXmlReportWriter junitXmlReportWriter,
-                             String thisTask)
-  {
-    this.resolvedTopLevelArtifacts = resolvedTopLevelArtifacts;
-    this.settings = settings;
-    this.junitXmlReportWriter = junitXmlReportWriter;
-    this.thisTask = thisTask;
-  }
-
-  public void reportResult(Collection<MavenPackageDescriptor> results) {
-    int vulnerabilities = getSumOfVulnerabilities(results);
-    if (vulnerabilities == 0) {
-      return;
+    public AuditResultReporter(Set<GradleArtifact> resolvedTopLevelArtifacts,
+                                                         AuditExtensions settings,
+                                                         JunitXmlReportWriter junitXmlReportWriter,
+                                                         String thisTask)
+    {
+        this.resolvedTopLevelArtifacts = resolvedTopLevelArtifacts;
+        this.settings = settings;
+        this.junitXmlReportWriter = junitXmlReportWriter;
+        this.thisTask = thisTask;
     }
 
-    int unignoredVulnerabilities = getUnignoredVulnerabilities(results);
+    public void reportResult(Collection<MavenPackageDescriptor> results) {
+        int vulnerabilities = getSumOfVulnerabilities(results);
+        if (vulnerabilities == 0) {
+            return;
+        }
 
-    allGradleArtifacts = getAllDependencies();
+        int unignoredVulnerabilities = getUnignoredVulnerabilities(results);
 
-    for (MavenPackageDescriptor descriptor : results) {
-      if (descriptor.getVulnerabilities() == null) {
-        logger.info("No vulnerabilities in " + descriptor.getMavenVersionId());
-        continue;
-      }
-      if (settings.isIgnored(descriptor)) {
-        logger.info(descriptor.getMavenVersionId() + " is ignored due to settings");
-        continue;
-      }
+        allGradleArtifacts = getAllDependencies();
 
-      // We already calculated unignored vulnerabilities. We need to include unexcluded vulnerabilities since they
-      // are handled by the audit library.
-      int actualVulnerabilities = descriptor.getVulnerabilities().size();
-      int expectedVulnerabilities = descriptor.getVulnerabilityMatches();
-      int unExcludedVulnerabilities = expectedVulnerabilities - actualVulnerabilities;
-      unignoredVulnerabilities -= unExcludedVulnerabilities;
+        for (MavenPackageDescriptor descriptor : results) {
+            if (descriptor.getVulnerabilities() == null) {
+                logger.info("No vulnerabilities in " + descriptor.getMavenVersionId());
+                continue;
+            }
+            if (settings.isIgnored(descriptor)) {
+                logger.info(descriptor.getMavenVersionId() + " is ignored due to settings");
+                continue;
+            }
 
-      // Now bail if exclusions cause all issues in this package to be ignored
-      if (actualVulnerabilities == 0) {
-        logger.info("Vulnerabilities in " + descriptor.getMavenVersionId() + " are excluded due to settings");
-        continue;
-      }
+            // We already calculated unignored vulnerabilities. We need to include unexcluded vulnerabilities since they
+            // are handled by the audit library.
+            int actualVulnerabilities = descriptor.getVulnerabilities().size();
+            int expectedVulnerabilities = descriptor.getVulnerabilityMatches();
+            int unExcludedVulnerabilities = expectedVulnerabilities - actualVulnerabilities;
+            unignoredVulnerabilities -= unExcludedVulnerabilities;
 
-      GradleArtifact importingGradleArtifact = findImportingArtifactFor(descriptor);
-      reportVulnerableArtifact(importingGradleArtifact, descriptor);
-      reportIntroducedVulnerabilities(descriptor);
+            // Now bail if exclusions cause all issues in this package to be ignored
+            if (actualVulnerabilities == 0) {
+                logger.info("Vulnerabilities in " + descriptor.getMavenVersionId() + " are excluded due to settings");
+                continue;
+            }
+
+            GradleArtifact importingGradleArtifact = findImportingArtifactFor(descriptor);
+            reportVulnerableArtifact(importingGradleArtifact, descriptor);
+            reportIntroducedVulnerabilities(descriptor);
+        }
+
+        currentVulnerabilityTotals = String.format("%s unignored (of %s total) vulnerabilities found",
+                unignoredVulnerabilities,
+                vulnerabilities);
+        logger.error(currentVulnerabilityTotals);
+
+        // Update the JUnit plugin XML report object
+        junitXmlReportWriter.updateJunitReport(currentVulnerabilityTotals,
+                thisTask,
+                currentVulnerableArtifact,
+                currentVulnerabilityList);
+
+        if (unignoredVulnerabilities > 0) {
+            throw new GradleException("Too many vulnerabilities (" + vulnerabilities + ") found.");
+        }
     }
 
-    currentVulnerabilityTotals = String.format("%s unignored (of %s total) vulnerabilities found",
-        unignoredVulnerabilities,
-        vulnerabilities);
-    logger.error(currentVulnerabilityTotals);
-
-    // Update the JUnit plugin XML report object
-    junitXmlReportWriter.updateJunitReport(currentVulnerabilityTotals,
-        thisTask,
-        currentVulnerableArtifact,
-        currentVulnerabilityList);
-
-    if (unignoredVulnerabilities > 0) {
-      throw new GradleException("Too many vulnerabilities (" + vulnerabilities + ") found.");
+    private void reportVulnerableArtifact(GradleArtifact importingArtifact, MavenPackageDescriptor descriptor) {
+        currentVulnerableArtifact = String.format("%s introduces %s which has %s vulnerabilities",
+                importingArtifact.getFullDescription(), descriptor.getMavenVersionId(), descriptor.getVulnerabilityMatches());
+        logger.error(currentVulnerableArtifact);
     }
-  }
 
-  private void reportVulnerableArtifact(GradleArtifact importingArtifact, MavenPackageDescriptor descriptor) {
-    currentVulnerableArtifact = String.format("%s introduces %s which has %s vulnerabilities",
-        importingArtifact.getFullDescription(), descriptor.getMavenVersionId(), descriptor.getVulnerabilityMatches());
-    logger.error(currentVulnerableArtifact);
-  }
+    private int reportIntroducedVulnerabilities(MavenPackageDescriptor descriptor) {
+        currentVulnerabilityList.clear();
+        List<OssiVulnerability> vulns = descriptor.getVulnerabilities();
+        vulns.forEach(v -> reportVulnerability(String.format("=> %s (see %s)", v.getTitle(), getUriString(v))));
+        return vulns.size();
+    }
 
-  private int reportIntroducedVulnerabilities(MavenPackageDescriptor descriptor) {
-    currentVulnerabilityList.clear();
-    List<OssiVulnerability> vulns = descriptor.getVulnerabilities();
-    vulns.forEach(v -> reportVulnerability(String.format("=> %s (see %s)", v.getTitle(), getUriString(v))));
-    return vulns.size();
-  }
+    private String getUriString(final OssiVulnerability v) {
+        return OSSI_VULN_PREFIX + v.getId();
+    }
 
-  private String getUriString(final OssiVulnerability v) {
-    return OSSI_VULN_PREFIX + v.getId();
-  }
+    private void reportVulnerability(String line) {
+        logger.error(line);
+        currentVulnerabilityList.add(line);
+    }
 
-  private void reportVulnerability(String line) {
-    logger.error(line);
-    currentVulnerabilityList.add(line);
-  }
+    private GradleArtifact findImportingArtifactFor(MavenPackageDescriptor mavenPackageDescriptor) {
+        return allGradleArtifacts
+                .stream()
+                .filter(a -> a.getFullDescription().equals(mavenPackageDescriptor.getMavenVersionId()))
+                .map(GradleArtifact::getTopMostParent)
+                .findAny()
+                .orElseThrow(() -> new GradleException(
+                        "Couldn't find importing artifact for " + mavenPackageDescriptor.getMavenVersionId()));
+    }
 
-  private GradleArtifact findImportingArtifactFor(MavenPackageDescriptor mavenPackageDescriptor) {
-    return allGradleArtifacts
-        .stream()
-        .filter(a -> a.getFullDescription().equals(mavenPackageDescriptor.getMavenVersionId()))
-        .map(GradleArtifact::getTopMostParent)
-        .findAny()
-        .orElseThrow(() -> new GradleException(
-            "Couldn't find importing artifact for " + mavenPackageDescriptor.getMavenVersionId()));
-  }
+    private Set<GradleArtifact> getAllDependencies() {
+        return resolvedTopLevelArtifacts.stream().flatMap(a -> a.getAllArtifacts().stream()).collect(Collectors.toSet());
+    }
 
-  private Set<GradleArtifact> getAllDependencies() {
-    return resolvedTopLevelArtifacts.stream().flatMap(a -> a.getAllArtifacts().stream()).collect(Collectors.toSet());
-  }
+    private int getSumOfVulnerabilities(Collection<MavenPackageDescriptor> results) {
+        return results.stream().mapToInt(MavenPackageDescriptor::getVulnerabilityMatches).sum();
+    }
 
-  private int getSumOfVulnerabilities(Collection<MavenPackageDescriptor> results) {
-    return results.stream().mapToInt(MavenPackageDescriptor::getVulnerabilityMatches).sum();
-  }
-
-  private int getUnignoredVulnerabilities(Collection<MavenPackageDescriptor> results) {
-    return results.stream().filter(d -> !settings.isIgnored(d))
-        .mapToInt(MavenPackageDescriptor::getVulnerabilityMatches).sum();
-  }
+    private int getUnignoredVulnerabilities(Collection<MavenPackageDescriptor> results) {
+        return results.stream().filter(d -> !settings.isIgnored(d))
+                .mapToInt(MavenPackageDescriptor::getVulnerabilityMatches).sum();
+    }
 }

--- a/src/main/java/net/ossindex/gradle/output/AuditResultReporter.java
+++ b/src/main/java/net/ossindex/gradle/output/AuditResultReporter.java
@@ -102,13 +102,8 @@ public class AuditResultReporter
   }
 
   private void reportVulnerableArtifact(GradleArtifact importingArtifact, MavenPackageDescriptor descriptor) {
-    if (importingArtifact != null) {
-      currentVulnerableArtifact = String.format("%s introduces %s which has %s vulnerabilities",
-          importingArtifact.getFullDescription(), descriptor.getMavenVersionId(), descriptor.getVulnerabilityMatches());
-    } else {
-      currentVulnerableArtifact = String.format("%s is a direct dependency and has %s vulnerabilities",
-          descriptor.getMavenVersionId(), descriptor.getVulnerabilityMatches());
-    }
+    currentVulnerableArtifact = String.format("%s introduces %s which has %s vulnerabilities",
+        importingArtifact.getFullDescription(), descriptor.getMavenVersionId(), descriptor.getVulnerabilityMatches());
     logger.error(currentVulnerableArtifact);
   }
 
@@ -134,7 +129,8 @@ public class AuditResultReporter
         .filter(a -> a.getFullDescription().equals(mavenPackageDescriptor.getMavenVersionId()))
         .map(GradleArtifact::getTopMostParent)
         .findAny()
-        .orElse(null);
+        .orElseThrow(() -> new GradleException(
+            "Couldn't find importing artifact for " + mavenPackageDescriptor.getMavenVersionId()));
   }
 
   private Set<GradleArtifact> getAllDependencies() {

--- a/src/main/java/net/ossindex/gradle/output/AuditResultReporter.java
+++ b/src/main/java/net/ossindex/gradle/output/AuditResultReporter.java
@@ -16,141 +16,141 @@ import org.slf4j.LoggerFactory;
 
 public class AuditResultReporter
 {
-  private static final Logger logger = LoggerFactory.getLogger(AuditResultReporter.class);
+    private static final Logger logger = LoggerFactory.getLogger(AuditResultReporter.class);
 
-  private static final String OSSI_VULN_PREFIX = "https://ossindex.sonatype.org/vuln/";
+    private static final String OSSI_VULN_PREFIX = "https://ossindex.sonatype.org/vuln/";
 
-  private final Set<GradleArtifact> resolvedTopLevelArtifacts;
+    private final Set<GradleArtifact> resolvedTopLevelArtifacts;
 
-  private final AuditExtensions settings;
+    private final AuditExtensions settings;
 
-  private Set<GradleArtifact> allGradleArtifacts;
+    private Set<GradleArtifact> allGradleArtifacts;
 
-  private String currentVulnerableArtifact = null;
+    private String currentVulnerableArtifact = null;
 
-  ArrayList<String> currentVulnerabilityList = new ArrayList<>();
+    ArrayList<String> currentVulnerabilityList = new ArrayList<>();
 
-  private String currentVulnerabilityTotals = null;
+    private String currentVulnerabilityTotals = null;
 
-  private String thisTask;
+    private String thisTask;
 
-  private JunitXmlReportWriter junitXmlReportWriter;
+    private JunitXmlReportWriter junitXmlReportWriter;
 
-  public AuditResultReporter(Set<GradleArtifact> resolvedTopLevelArtifacts,
-                             AuditExtensions settings,
-                             JunitXmlReportWriter junitXmlReportWriter,
-                             String thisTask)
-  {
-    this.resolvedTopLevelArtifacts = resolvedTopLevelArtifacts;
-    this.settings = settings;
-    this.junitXmlReportWriter = junitXmlReportWriter;
-    this.thisTask = thisTask;
-  }
-
-  public void reportResult(Collection<MavenPackageDescriptor> results) {
-    int vulnerabilities = getSumOfVulnerabilities(results);
-    if (vulnerabilities == 0) {
-      return;
+    public AuditResultReporter(Set<GradleArtifact> resolvedTopLevelArtifacts,
+                                                         AuditExtensions settings,
+                                                         JunitXmlReportWriter junitXmlReportWriter,
+                                                         String thisTask)
+    {
+        this.resolvedTopLevelArtifacts = resolvedTopLevelArtifacts;
+        this.settings = settings;
+        this.junitXmlReportWriter = junitXmlReportWriter;
+        this.thisTask = thisTask;
     }
 
-    int unignoredVulnerabilities = getUnignoredVulnerabilities(results);
+    public void reportResult(Collection<MavenPackageDescriptor> results) {
+        int vulnerabilities = getSumOfVulnerabilities(results);
+        if (vulnerabilities == 0) {
+            return;
+        }
 
-    allGradleArtifacts = getAllDependencies();
+        int unignoredVulnerabilities = getUnignoredVulnerabilities(results);
 
-    for (MavenPackageDescriptor descriptor : results) {
-      if (descriptor.getVulnerabilities() == null) {
-        logger.info("No vulnerabilities in " + descriptor.getMavenVersionId());
-        continue;
-      }
-      if (settings.isIgnored(descriptor)) {
-        logger.info(descriptor.getMavenVersionId() + " is ignored due to settings");
-        continue;
-      }
+        allGradleArtifacts = getAllDependencies();
 
-      // We already calculated unignored vulnerabilities. We need to include unexcluded vulnerabilities since they
-      // are handled by the audit library.
-      int actualVulnerabilities = descriptor.getVulnerabilities().size();
-      int expectedVulnerabilities = descriptor.getVulnerabilityMatches();
-      int unExcludedVulnerabilities = expectedVulnerabilities - actualVulnerabilities;
-      unignoredVulnerabilities -= unExcludedVulnerabilities;
+        for (MavenPackageDescriptor descriptor : results) {
+            if (descriptor.getVulnerabilities() == null) {
+                logger.info("No vulnerabilities in " + descriptor.getMavenVersionId());
+                continue;
+            }
+            if (settings.isIgnored(descriptor)) {
+                logger.info(descriptor.getMavenVersionId() + " is ignored due to settings");
+                continue;
+            }
 
-      // Now bail if exclusions cause all issues in this package to be ignored
-      if (actualVulnerabilities == 0) {
-        logger.info("Vulnerabilities in " + descriptor.getMavenVersionId() + " are excluded due to settings");
-        continue;
-      }
+            // We already calculated unignored vulnerabilities. We need to include unexcluded vulnerabilities since they
+            // are handled by the audit library.
+            int actualVulnerabilities = descriptor.getVulnerabilities().size();
+            int expectedVulnerabilities = descriptor.getVulnerabilityMatches();
+            int unExcludedVulnerabilities = expectedVulnerabilities - actualVulnerabilities;
+            unignoredVulnerabilities -= unExcludedVulnerabilities;
 
-      GradleArtifact importingGradleArtifact = null;
-      try {
-        importingGradleArtifact = findImportingArtifactFor(descriptor);
-      }
-      catch (GradleException ignore) {
-        // This seems to mean that this is a top level artifact
-      }
-      reportVulnerableArtifact(importingGradleArtifact, descriptor);
-      reportIntroducedVulnerabilities(descriptor);
+            // Now bail if exclusions cause all issues in this package to be ignored
+            if (actualVulnerabilities == 0) {
+                logger.info("Vulnerabilities in " + descriptor.getMavenVersionId() + " are excluded due to settings");
+                continue;
+            }
+
+            GradleArtifact importingGradleArtifact = null;
+            try {
+                importingGradleArtifact = findImportingArtifactFor(descriptor);
+            }
+            catch (GradleException ignore) {
+                // This seems to mean that this is a top level artifact
+            }
+            reportVulnerableArtifact(importingGradleArtifact, descriptor);
+            reportIntroducedVulnerabilities(descriptor);
+        }
+
+        currentVulnerabilityTotals = String.format("%s unignored (of %s total) vulnerabilities found",
+                unignoredVulnerabilities,
+                vulnerabilities);
+        logger.error(currentVulnerabilityTotals);
+
+        // Update the JUnit plugin XML report object
+        junitXmlReportWriter.updateJunitReport(currentVulnerabilityTotals,
+                thisTask,
+                currentVulnerableArtifact,
+                currentVulnerabilityList);
+
+        if (unignoredVulnerabilities > 0) {
+            throw new GradleException("Too many vulnerabilities (" + vulnerabilities + ") found.");
+        }
     }
 
-    currentVulnerabilityTotals = String.format("%s unignored (of %s total) vulnerabilities found",
-        unignoredVulnerabilities,
-        vulnerabilities);
-    logger.error(currentVulnerabilityTotals);
-
-    // Update the JUnit plugin XML report object
-    junitXmlReportWriter.updateJunitReport(currentVulnerabilityTotals,
-        thisTask,
-        currentVulnerableArtifact,
-        currentVulnerabilityList);
-
-    if (unignoredVulnerabilities > 0) {
-      throw new GradleException("Too many vulnerabilities (" + vulnerabilities + ") found.");
+    private void reportVulnerableArtifact(GradleArtifact importingArtifact, MavenPackageDescriptor descriptor) {
+        currentVulnerableArtifact = importingArtifact == null ?
+                String.format("%s has %s vulnerabilities", descriptor.getMavenVersionId(), descriptor.getVulnerabilityMatches())
+                : String.format("%s introduces %s which has %s vulnerabilities", importingArtifact.getFullDescription(),
+                descriptor.getMavenVersionId(), descriptor.getVulnerabilityMatches());
+        logger.error(currentVulnerableArtifact);
     }
-  }
 
-  private void reportVulnerableArtifact(GradleArtifact importingArtifact, MavenPackageDescriptor descriptor) {
-    currentVulnerableArtifact = importingArtifact == null ?
-        String.format("%s has %s vulnerabilities", descriptor.getMavenVersionId(), descriptor.getVulnerabilityMatches())
-        : String.format("%s introduces %s which has %s vulnerabilities", importingArtifact.getFullDescription(),
-        descriptor.getMavenVersionId(), descriptor.getVulnerabilityMatches());
-    logger.error(currentVulnerableArtifact);
-  }
+    private int reportIntroducedVulnerabilities(MavenPackageDescriptor descriptor) {
+        currentVulnerabilityList.clear();
+        List<OssiVulnerability> vulns = descriptor.getVulnerabilities();
+        vulns.forEach(v -> reportVulnerability(String.format("=> %s (see %s)", v.getTitle(), getUriString(v))));
+        return vulns.size();
+    }
 
-  private int reportIntroducedVulnerabilities(MavenPackageDescriptor descriptor) {
-    currentVulnerabilityList.clear();
-    List<OssiVulnerability> vulns = descriptor.getVulnerabilities();
-    vulns.forEach(v -> reportVulnerability(String.format("=> %s (see %s)", v.getTitle(), getUriString(v))));
-    return vulns.size();
-  }
+    private String getUriString(final OssiVulnerability v) {
+        return OSSI_VULN_PREFIX + v.getId();
+    }
 
-  private String getUriString(final OssiVulnerability v) {
-    return OSSI_VULN_PREFIX + v.getId();
-  }
+    private void reportVulnerability(String line) {
+        logger.error(line);
+        currentVulnerabilityList.add(line);
+    }
 
-  private void reportVulnerability(String line) {
-    logger.error(line);
-    currentVulnerabilityList.add(line);
-  }
+    private GradleArtifact findImportingArtifactFor(MavenPackageDescriptor mavenPackageDescriptor) {
+        return allGradleArtifacts
+                .stream()
+                .filter(a -> a.getFullDescription().equals(mavenPackageDescriptor.getMavenVersionId()))
+                .map(GradleArtifact::getTopMostParent)
+                .findAny()
+                .orElseThrow(() -> new GradleException(
+                        "Couldn't find importing artifact for " + mavenPackageDescriptor.getMavenVersionId()));
+    }
 
-  private GradleArtifact findImportingArtifactFor(MavenPackageDescriptor mavenPackageDescriptor) {
-    return allGradleArtifacts
-        .stream()
-        .filter(a -> a.getFullDescription().equals(mavenPackageDescriptor.getMavenVersionId()))
-        .map(GradleArtifact::getTopMostParent)
-        .findAny()
-        .orElseThrow(() -> new GradleException(
-            "Couldn't find importing artifact for " + mavenPackageDescriptor.getMavenVersionId()));
-  }
+    private Set<GradleArtifact> getAllDependencies() {
+        return resolvedTopLevelArtifacts.stream().flatMap(a -> a.getAllArtifacts().stream()).collect(Collectors.toSet());
+    }
 
-  private Set<GradleArtifact> getAllDependencies() {
-    return resolvedTopLevelArtifacts.stream().flatMap(a -> a.getAllArtifacts().stream()).collect(Collectors.toSet());
-  }
+    private int getSumOfVulnerabilities(Collection<MavenPackageDescriptor> results) {
+        return results.stream().mapToInt(MavenPackageDescriptor::getVulnerabilityMatches).sum();
+    }
 
-  private int getSumOfVulnerabilities(Collection<MavenPackageDescriptor> results) {
-    return results.stream().mapToInt(MavenPackageDescriptor::getVulnerabilityMatches).sum();
-  }
-
-  private int getUnignoredVulnerabilities(Collection<MavenPackageDescriptor> results) {
-    return results.stream().filter(d -> !settings.isIgnored(d))
-        .mapToInt(MavenPackageDescriptor::getVulnerabilityMatches).sum();
-  }
+    private int getUnignoredVulnerabilities(Collection<MavenPackageDescriptor> results) {
+        return results.stream().filter(d -> !settings.isIgnored(d))
+                .mapToInt(MavenPackageDescriptor::getVulnerabilityMatches).sum();
+    }
 }

--- a/src/main/java/net/ossindex/gradle/output/AuditResultReporter.java
+++ b/src/main/java/net/ossindex/gradle/output/AuditResultReporter.java
@@ -102,8 +102,13 @@ public class AuditResultReporter
   }
 
   private void reportVulnerableArtifact(GradleArtifact importingArtifact, MavenPackageDescriptor descriptor) {
-    currentVulnerableArtifact = String.format("%s introduces %s which has %s vulnerabilities",
-        importingArtifact.getFullDescription(), descriptor.getMavenVersionId(), descriptor.getVulnerabilityMatches());
+    if (importingArtifact != null) {
+      currentVulnerableArtifact = String.format("%s introduces %s which has %s vulnerabilities",
+          importingArtifact.getFullDescription(), descriptor.getMavenVersionId(), descriptor.getVulnerabilityMatches());
+    } else {
+      currentVulnerableArtifact = String.format("%s is a direct dependency and has %s vulnerabilities",
+          descriptor.getMavenVersionId(), descriptor.getVulnerabilityMatches());
+    }
     logger.error(currentVulnerableArtifact);
   }
 
@@ -129,8 +134,7 @@ public class AuditResultReporter
         .filter(a -> a.getFullDescription().equals(mavenPackageDescriptor.getMavenVersionId()))
         .map(GradleArtifact::getTopMostParent)
         .findAny()
-        .orElseThrow(() -> new GradleException(
-            "Couldn't find importing artifact for " + mavenPackageDescriptor.getMavenVersionId()));
+        .orElse(null);
   }
 
   private Set<GradleArtifact> getAllDependencies() {

--- a/src/main/java/net/ossindex/gradle/output/AuditResultReporter.java
+++ b/src/main/java/net/ossindex/gradle/output/AuditResultReporter.java
@@ -109,8 +109,14 @@ public class AuditResultReporter
 
     private void reportVulnerableArtifact(GradleArtifact importingArtifact, MavenPackageDescriptor descriptor) {
         currentVulnerableArtifact = importingArtifact == null ?
-                String.format("%s has %s vulnerabilities", descriptor.getMavenVersionId(), descriptor.getVulnerabilityMatches())
-                : String.format("%s introduces %s which has %s vulnerabilities", importingArtifact.getFullDescription(),
+            String.format("%s introduces %s which has %s vulnerabilities",
+                descriptor.getMavenVersionId(),
+                descriptor.getMavenVersionId(),
+                descriptor.getVulnerabilityMatches()) :
+            String.format("%s introduces %s which has %s vulnerabilities",
+                importingArtifact.getFullDescription(),
+                descriptor.getMavenVersionId(),
+                descriptor.getVulnerabilityMatches());
                 descriptor.getMavenVersionId(), descriptor.getVulnerabilityMatches());
         logger.error(currentVulnerableArtifact);
     }

--- a/src/main/java/net/ossindex/gradle/output/JunitXmlReportWriter.java
+++ b/src/main/java/net/ossindex/gradle/output/JunitXmlReportWriter.java
@@ -1,5 +1,6 @@
 package net.ossindex.gradle.output;
 
+import org.gradle.api.GradleException;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -171,7 +172,7 @@ public class JunitXmlReportWriter {
     }
 
     private Boolean parentDirIsWritable(String pathToReport) throws java.io.IOException {
-        File dir = new File(pathToReport);
+        File dir = new File(pathToReport).getAbsoluteFile();
         String parentDir = dir.getParent();
         if (parentDir != null) {
             Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(Paths.get(parentDir), LinkOption.NOFOLLOW_LINKS);


### PR DESCRIPTION
Several updates all related to using the OSS Index 3.0 API. Including:

* Using the new API, which provides many more vulnerabilities and is actively maintained (the v2 database is no longer being maintained).
* Adding credentials (authentication support) which is useful as the v3 API uses rate limiting (which will not affect many users, depending on the scale of their use).
* Results caching to combat rate limiting

A “shadow jar” available for downloading here: https://github.com/OSSIndex/ossindex-gradle-plugin/releases/tag/0.4.0-beta1

There is a minor explanation of how to use the shadow jar on the download page, and more information about the new features can be seen on the v3.0 branch readme: https://github.com/OSSIndex/ossindex-gradle-plugin/blob/8731522c6da65df179bc525e037e4804ed819c78/README.md