### PR TITLE
Configure build-scan plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+
+language: groovy
+
+script:
+  - ./gradlew --scan build
+
+jdk:
+  - oraclejdk8

--- a/build.gradle
+++ b/build.gradle
@@ -1,28 +1,21 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
 
-buildscript {
-    repositories {
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-        jcenter()
+plugins {
+    id 'com.gradle.build-scan' version '2.2.1'
+    id 'groovy'
+    id 'maven'
+    id 'java-gradle-plugin'
+    id 'com.gradle.plugin-publish' version '0.10.1'
+    id 'com.github.johnrengelman.shadow' version '4.0.4'
+}
 
-    }
-    dependencies {
-        classpath "com.gradle.publish:plugin-publish-plugin:0.10.1"
-        classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.4'
-    }
+buildScan {
+    termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+    apply from: 'gradle/build-scans.gradle'
 }
 
 group 'net.ossindex'
 version '0.4.8'
-
-apply plugin: "com.gradle.plugin-publish"
-apply plugin: 'java'
-apply plugin: 'groovy'
-apply plugin: 'maven'
-apply plugin: 'java-gradle-plugin'
-apply plugin: 'com.github.johnrengelman.shadow'
 
 sourceCompatibility = 1.8
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.daemon   = true
+org.gradle.caching  = true
+org.gradle.parallel = true

--- a/gradle/build-scans.gradle
+++ b/gradle/build-scans.gradle
@@ -1,0 +1,33 @@
+def acceptFile = new File(gradle.gradleUserHomeDir, "build-scans/ossindex/gradle-scans-license-agree.txt")
+def env = System.getenv()
+boolean isCI = env.CI || env.TRAVIS
+boolean hasAccepted = isCI || env.OSSINDEX_GRADLE_SCANS_ACCEPT=='yes' || acceptFile.exists() && acceptFile.text.trim() == 'yes'
+boolean hasRefused = env.OSSINDEX_GRADLE_SCANS_ACCEPT=='no' || acceptFile.exists() && acceptFile.text.trim() == 'no'
+
+buildScan {
+    if (hasAccepted) {
+        termsOfServiceAgree = 'yes'
+    } else if (!hasRefused) {
+        gradle.buildFinished {
+            println """
+This build uses Gradle Build Scans to gather statistics, share information about 
+failures, environmental issues, dependencies resolved during the build and more.
+Build scans will be published after each build, if you accept the terms of 
+service, and in particular the privacy policy.
+
+Please read 
+   
+    https://gradle.com/terms-of-service 
+    https://gradle.com/legal/privacy
+
+and then:
+
+  - set the `OSSINDEX_GRADLE_SCANS_ACCEPT` to `yes`/`no` if you agree with/refuse the TOS
+  - or create the ${acceptFile} file with `yes`/`no` in it if you agree with/refuse
+
+And we'll not bother you again. Note that build scans are only made public if 
+you share the URL at the end of the build.
+"""
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,10 @@
+pluginManagement {
+    repositories {
+        jcenter()
+        gradlePluginPortal()
+    }
+}
+
 rootProject.name = 'ossindex-gradle-plugin'
 
 include 'ossi-mapdb'


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.